### PR TITLE
Add labels to container info spec

### DIFF
--- a/container/hyper/handler.go
+++ b/container/hyper/handler.go
@@ -145,6 +145,8 @@ func (self *hyperContainerHandler) GetSpec() (info.ContainerSpec, error) {
 	spec.HasNetwork = true
 	spec.HasCustomMetrics = false
 
+	spec.Labels = podInfo.Spec.Labels
+
 	return spec, nil
 }
 


### PR DESCRIPTION
Heapster expected a series labels to when `GetSpec`, in order to parse container name, pod namespace etc.
